### PR TITLE
Minor enhancements

### DIFF
--- a/fake_policy_test.go
+++ b/fake_policy_test.go
@@ -11,13 +11,13 @@ type FakePolicy struct {
 	value   *int
 }
 
-func FakePolicyMerger(overrides FakePolicy, defaults FakePolicy) FakePolicy {
-	result := overrides
+func FakePolicyMerger(p1 FakePolicy, p2 FakePolicy) FakePolicy {
+	result := p1
 	if result.enabled == nil {
-		result.enabled = defaults.enabled
+		result.enabled = p2.enabled
 	}
 	if result.value == nil {
-		result.value = defaults.value
+		result.value = p2.value
 	}
 	return result
 }

--- a/fake_policy_test.go
+++ b/fake_policy_test.go
@@ -2,6 +2,8 @@ package gw_policies_playground
 
 import (
 	"testing"
+
+	"gotest.tools/assert"
 )
 
 type FakePolicy struct {
@@ -25,12 +27,10 @@ func TestRouteSimpleMerge(t *testing.T) {
 	gw := gwc.CreateGateway("gw")
 	route := gw.CreateRoute("route")
 
-	if gw.parent != &gwc || gw.name != "gw" {
-		t.Fail()
-	}
-	if route.parent != gw || route.name != "route" {
-		t.Fail()
-	}
+  assert.Equal(t, gw.parent, &gwc)
+  assert.Equal(t, gw.name, "gw")
+  assert.Equal(t, route.parent, gw)
+  assert.Equal(t, route.name, "route")
 
 	value := 42
 	enabled := true
@@ -42,17 +42,12 @@ func TestRouteSimpleMerge(t *testing.T) {
 	}
 	route.AddPolicy(policy)
 
-	if route.policies[0] != policy {
-		t.Fail()
-	}
+  assert.Equal(t, route.policies[0], policy)
 
 	result := route.MergedPolicies(FakePolicyMerger)
-	if *result.value != 42 {
-		t.Fail()
-	}
-	if *result.enabled != true {
-		t.Fail()
-	}
+
+	assert.Equal(t, *result.value, 42)
+	assert.Check(t, *result.enabled)
 }
 
 func TestRouteGwMerge(t *testing.T) {
@@ -60,12 +55,10 @@ func TestRouteGwMerge(t *testing.T) {
 	gw := gwc.CreateGateway("gw")
 	route := gw.CreateRoute("route")
 
-	if gw.parent != &gwc || gw.name != "gw" {
-		t.Fail()
-	}
-	if route.parent != gw || route.name != "route" {
-		t.Fail()
-	}
+  assert.Equal(t, gw.parent, &gwc)
+  assert.Equal(t, gw.name, "gw")
+  assert.Equal(t, route.parent, gw)
+  assert.Equal(t, route.name, "route")
 
 	gwDefault := 42
 	routeOverride := 420
@@ -86,12 +79,8 @@ func TestRouteGwMerge(t *testing.T) {
 	route.AddPolicy(routePolicy)
 
 	result := route.MergedPolicies(FakePolicyMerger)
-	if *result.value != 420 {
-		t.Fail()
-	}
-	if *result.enabled != true {
-		t.Fail()
-	}
+	assert.Equal(t, *result.value, 420)
+	assert.Check(t, *result.enabled)
 }
 
 func TestRouteGwMergeDefaults(t *testing.T) {
@@ -119,10 +108,6 @@ func TestRouteGwMergeDefaults(t *testing.T) {
 	route.AddPolicy(routePolicy)
 
 	result := route.MergedPolicies(FakePolicyMerger)
-	if *result.value != 420 {
-		t.Fail()
-	}
-	if *result.enabled != true {
-		t.Fail()
-	}
+	assert.Equal(t, *result.value, 420)
+	assert.Check(t, *result.enabled)
 }

--- a/fake_policy_test.go
+++ b/fake_policy_test.go
@@ -72,7 +72,7 @@ func TestRouteGwMerge(t *testing.T) {
 	gw.AddPolicy(gwPolicy)
 
 	routePolicy := PolicySpec[FakePolicy]{
-		name:      "gw_policy",
+		name:      "route_policy",
 		defaults:  FakePolicy{value: &gwDefault},
 		overrides: FakePolicy{value: &routeOverride},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module gw-policies-playground
 
 go 1.18
+
+require gotest.tools v2.2.0+incompatible
+
+require (
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=


### PR DESCRIPTION
- [x] Use assertions (from [gotest.tools/assert](https://pkg.go.dev/gotest.tools@v2.2.0+incompatible/assert?utm_source=gopls))
- [x] Fix the name of route policy in the tests
- [x] Rename merging policy parameters as `p1` and `p2`